### PR TITLE
fixed incorrect mime type lookup if trailing slash converted to index.ht...

### DIFF
--- a/lib/gzip-static.js
+++ b/lib/gzip-static.js
@@ -38,16 +38,19 @@ module.exports = function(root, options) {
       return passToStatic();
     }
 
-    name.orig = utils.parseUrl(req).pathname;
-    if (name.orig[name.orig.length - 1] === '/') {
-      name.index = (options.index || 'index.html') + '.gz';
-      name.gz = name.orig;
-      name.full = path.join(root, name.orig + name.index);
-      debug('Index request %s, check for %s', req.url, name.full);
-    } else {
-      name.gz = name.orig + '.gz';
+      name.orig = utils.parseUrl(req).pathname;
+
+      // If trailing slash found default to index or
+      // else use orginal request
+      if ('/' === name.orig[name.orig.length - 1]) {
+          name.document = (options.index || 'index.html');
+      } else {
+          name.document = name.orig;
+      }
+
+      // Modify document to look for gzip'd file
+      name.gz   = name.document + '.gz';
       name.full = path.join(root, name.gz);
-    }
 
     fs.stat(name.full, function(err, stat) {
       var exists = !err && stat.isFile();
@@ -56,7 +59,11 @@ module.exports = function(root, options) {
         return passToStatic();
       }
       debug('Sending %s', name.full);
-      setHeader(res, name.orig);
+
+      // Use the document name (original or derived) to set header
+      // content type etc.
+      setHeader(res, name.document);
+
       send(req, name.gz)
         .maxage(options.maxAge || 0)
         .root(root)


### PR DESCRIPTION
I basically tested this with 

www.mysite.com 
www.mysite.com/
www.mysite.com/index.html

If the file is gzip'd it now sets mime type correctly and returns the document vs. downloading it with the above scenario's, it also falls through properly to connect's static handler if it can't be found as before 

Seems to take care of the issues, and browser side 304's also seem to be returned properly etc. but note that I didn't test the trailing / scenario outside of above root scenarios
