### PR TITLE
Add a debugging section in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,10 @@ connect()
   .use(gzipStatic(__dirname + '/public', { maxAge: oneDay }))
 ```
 
+## Debugging
+
+This project uses [debug module](https://github.com/visionmedia/debug). To enable the debug log, just set the debug enviromental variable: `DEBUG="connect:gzip-static"`
+
 # License
 
 MIT


### PR DESCRIPTION
I love the fact that this module uses `debug`. But everyone who uses this should know about it. It would be useless to have this, if the module users don't know about it :)
